### PR TITLE
Correcting include files to allow for particular symbols (e.g., WEXIT…

### DIFF
--- a/src/tests/testparseerror.c
+++ b/src/tests/testparseerror.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 char *g_name     = NULL;


### PR DESCRIPTION
…STATUS) to be visible